### PR TITLE
add a default action for copying the device name

### DIFF
--- a/extensions/toothpick/CHANGELOG.md
+++ b/extensions/toothpick/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Toothpick Changelog
 
+## [Hotfix] - 2025-01-21
+
+- Add an action for copying the device name
+
 ## [Hotfix] - 2024-05-15
 
 - Fixed device not disconnecting sometimes on AppleScript backend.

--- a/extensions/toothpick/package.json
+++ b/extensions/toothpick/package.json
@@ -10,7 +10,8 @@
     "sxn",
     "pernielsentikaer",
     "rspeicher",
-    "roele"
+    "roele",
+    "antonniklasson"
   ],
   "repository": {
     "type": "git",
@@ -240,3 +241,4 @@
   "license": "MIT",
   "icon": "icon.png"
 }
+

--- a/extensions/toothpick/src/core/devices/devices.model.tsx
+++ b/extensions/toothpick/src/core/devices/devices.model.tsx
@@ -78,6 +78,12 @@ export class Device {
         onAction={() => Clipboard.copy(JSON.stringify(this.rawDeviceData))}
         icon={Icon.ComputerChip}
       />,
+      <Action
+        title={`Copy Device Name`}
+        key="copy-device-name"
+        onAction={() => Clipboard.copy(this.name)}
+        icon={Icon.Pencil}
+      />,
       ...additionalActions,
     ];
   }


### PR DESCRIPTION
## Description

This change adds a new default action to the device listing: "Copy Device Name". I needed this for setting up the "Connect Favorite Command". 

Let me know if doesn't is easier solved in some other way, I found it pretty convenient.

<img src="https://github.com/user-attachments/assets/a0b8c18c-3bd4-4fc3-a3ea-953dc1417057" alt="Screenshot 2025-01-21 at 09 43 16" width="300px">


## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
